### PR TITLE
Renaming module suffix "*Mod" => "*".

### DIFF
--- a/src/Complex128Vector.F90
+++ b/src/Complex128Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Complex128VectorMod
+module gFTL_Complex128Vector
   use, intrinsic :: iso_fortran_env, only: REAL128
 
 #define _type type(complex(kind=REAL128))
@@ -9,4 +9,4 @@ module gFTL_Complex128VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Complex128VectorMod
+end module gFTL_Complex128Vector

--- a/src/Complex32Vector.F90
+++ b/src/Complex32Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Complex32VectorMod
+module gFTL_Complex32Vector
   use, intrinsic :: iso_fortran_env, only: REAL32
 
 #define _type type(complex(kind=REAL32))
@@ -9,4 +9,4 @@ module gFTL_Complex32VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Complex32VectorMod
+end module gFTL_Complex32Vector

--- a/src/Complex64Vector.F90
+++ b/src/Complex64Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Complex64VectorMod
+module gFTL_Complex64Vector
   use, intrinsic :: iso_fortran_env, only: REAL64
 
 #define _type type(complex(kind=REAL64))
@@ -9,4 +9,4 @@ module gFTL_Complex64VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Complex64VectorMod
+end module gFTL_Complex64Vector

--- a/src/ComplexVector.F90
+++ b/src/ComplexVector.F90
@@ -1,14 +1,14 @@
-module gFTL_ComplexVectorMod
+module gFTL_ComplexVector
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_Complex32VectorMod, only: ComplexVector => Complex32Vector
-  use gFTL_Complex32VectorMod, only: ComplexVectorIterator => Complex32VectorIterator
+  use gFTL_Complex32Vector, only: ComplexVector => Complex32Vector
+  use gFTL_Complex32Vector, only: ComplexVectorIterator => Complex32VectorIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Complex64VectorMod, only: ComplexVector => Complex64Vector
-  use gFTL_Complex64VectorMod, only: ComplexVectorIterator => Complex64VectorIterator
+  use gFTL_Complex64Vector, only: ComplexVector => Complex64Vector
+  use gFTL_Complex64Vector, only: ComplexVectorIterator => Complex64VectorIterator
 
 #else
 
@@ -22,4 +22,4 @@ module gFTL_ComplexVectorMod
 
 #endif
   
-end module gFTL_ComplexVectorMod
+end module gFTL_ComplexVector

--- a/src/DoubleComplexVector.F90
+++ b/src/DoubleComplexVector.F90
@@ -1,14 +1,14 @@
-module gFTL_DoubleComplexVectorMod
+module gFTL_DoubleComplexVector
 
 #if _DOUBLE_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_DoubleComplex64VectorMod, only: DoubleComplexVector => Complex64Vector
-  use gFTL_DoubleComplex64VectorMod, only: DoubleComplexVectorIterator => Complex64VectorIterator
+  use gFTL_DoubleComplex64Vector, only: DoubleComplexVector => Complex64Vector
+  use gFTL_DoubleComplex64Vector, only: DoubleComplexVectorIterator => Complex64VectorIterator
 
 #elif defined(_ISO_REAL128) && (_DOUBLE_DEAULT_KIND == _ISO_REAL128)
 
-  use gFTL_DoubleComplex64VectorMod, only: DoubleComplexVector => ComplexVector
-  use gFTL_DoubleComplex64VectorMod, only: DoubleComplexVectorIterator => Complex128VectorIterator
+  use gFTL_DoubleComplex64Vector, only: DoubleComplexVector => ComplexVector
+  use gFTL_DoubleComplex64Vector, only: DoubleComplexVectorIterator => Complex128VectorIterator
 
 #else
 
@@ -22,4 +22,4 @@ module gFTL_DoubleComplexVectorMod
 
 #endif
   
-end module gFTL_DoubleComplexVectorMod
+end module gFTL_DoubleComplexVector

--- a/src/DoubleVector.F90
+++ b/src/DoubleVector.F90
@@ -1,14 +1,14 @@
-module gFTL_DoubleVectorMod
+module gFTL_DoubleVector
 
 #if _DOUBLE_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Double64VectorMod, only: DoubleVector => Real64Vector
-  use gFTL_Double64VectorMod, only: DoubleVectorIterator => Real64VectorIterator
+  use gFTL_Double64Vector, only: DoubleVector => Real64Vector
+  use gFTL_Double64Vector, only: DoubleVectorIterator => Real64VectorIterator
 
 #elif defined(_ISO_REAL128) && (_DOUBLE_DEAULT_KIND == _ISO_REAL128)
 
-  use gFTL_Real128VectorMod, only: DoubleVector => Real128Vector
-  use gFTL_Real128VectorMod, only: DoubleVectorIterator => Real128VectorIterator
+  use gFTL_Real128Vector, only: DoubleVector => Real128Vector
+  use gFTL_Real128Vector, only: DoubleVectorIterator => Real128VectorIterator
 
 #else
 
@@ -22,4 +22,4 @@ module gFTL_DoubleVectorMod
 
 #endif
   
-end module gFTL_DoubleVectorMod
+end module gFTL_DoubleVector

--- a/src/Integer32Complex128Map.F90
+++ b/src/Integer32Complex128Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Complex128MapMod
+module gFTL_Integer32Complex128Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL128
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Complex128MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Complex128MapMod
+end module gFTL_Integer32Complex128Map

--- a/src/Integer32Complex32Map.F90
+++ b/src/Integer32Complex32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Complex32MapMod
+module gFTL_Integer32Complex32Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL32
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Complex32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Complex32MapMod
+end module gFTL_Integer32Complex32Map

--- a/src/Integer32Complex64Map.F90
+++ b/src/Integer32Complex64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Complex64MapMod
+module gFTL_Integer32Complex64Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL64
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Complex64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Complex64MapMod
+end module gFTL_Integer32Complex64Map

--- a/src/Integer32ComplexMap.F90
+++ b/src/Integer32ComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer32ComplexMapMod
+module gFTL_Integer32ComplexMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_Integer32Complex32MapMod, only: Integer32ComplexMap => Integer32Complex32Map
-  use gFTL_Integer32Complex32MapMod, only: Integer32ComplexMapIterator => Integer32Complex32MapIterator
+  use gFTL_Integer32Complex32Map, only: Integer32ComplexMap => Integer32Complex32Map
+  use gFTL_Integer32Complex32Map, only: Integer32ComplexMapIterator => Integer32Complex32MapIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer32Complex64MapMod, only: Integer32ComplexMap => Integer32Complex64Map
-  use gFTL_Integer32Complex64MapMod, only: Integer32ComplexMapIterator => Integer32Complex64MapIterator
+  use gFTL_Integer32Complex64Map, only: Integer32ComplexMap => Integer32Complex64Map
+  use gFTL_Integer32Complex64Map, only: Integer32ComplexMapIterator => Integer32Complex64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer32ComplexMapMod
 
 #endif
 
-end module gFTL_Integer32ComplexMapMod
+end module gFTL_Integer32ComplexMap

--- a/src/Integer32DoubleComplexMap.F90
+++ b/src/Integer32DoubleComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer32DoubleComplexMapMod
+module gFTL_Integer32DoubleComplexMap
 
 #if _DOUBLE_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer32Complex64MapMod, only: Integer32DoubleComplexMap => Integer32Complex64Map
-  use gFTL_Integer32Complex64MapMod, only: Integer32DoubleComplexMapIterator => Integer32Complex64MapIterator
+  use gFTL_Integer32Complex64Map, only: Integer32DoubleComplexMap => Integer32Complex64Map
+  use gFTL_Integer32Complex64Map, only: Integer32DoubleComplexMapIterator => Integer32Complex64MapIterator
 
 #elif _DOUBLE_DEAULT_KIND == _ISO_REAL128
 
-  use gFTL_Integer32Complex128MapMod, only: Integer32DoubleComplexMap => Integer32Complex128Map
-  use gFTL_Integer32Complex128MapMod, only: Integer32DoubleComplexMapIterator => Integer32Complex128MapIterator
+  use gFTL_Integer32Complex128Map, only: Integer32DoubleComplexMap => Integer32Complex128Map
+  use gFTL_Integer32Complex128Map, only: Integer32DoubleComplexMapIterator => Integer32Complex128MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer32DoubleComplexMapMod
 
 #endif
 
-end module gFTL_Integer32DoubleComplexMapMod
+end module gFTL_Integer32DoubleComplexMap

--- a/src/Integer32DoubleMap.F90
+++ b/src/Integer32DoubleMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer32DoubleMapMod
+module gFTL_Integer32DoubleMap
 
 #if _DOUBLE_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer32Real64MapMod, only: Integer32DoubleMap => Integer32Real64Map
-  use gFTL_Integer32Real64MapMod, only: Integer32DoubleMapIterator => Integer32Real64MapIterator
+  use gFTL_Integer32Real64Map, only: Integer32DoubleMap => Integer32Real64Map
+  use gFTL_Integer32Real64Map, only: Integer32DoubleMapIterator => Integer32Real64MapIterator
 
 #elif _DOUBLE_DEAULT_KIND == _ISO_REAL128
 
-  use gFTL_Integer32Real128MapMod, only: Integer32DoubleMap => Integer32Real128Map
-  use gFTL_Integer32Real128MapMod, only: Integer32DoubleMapIterator => Integer32Real128MapIterator
+  use gFTL_Integer32Real128Map, only: Integer32DoubleMap => Integer32Real128Map
+  use gFTL_Integer32Real128Map, only: Integer32DoubleMapIterator => Integer32Real128MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer32DoubleMapMod
 
 #endif
 
-end module gFTL_Integer32DoubleMapMod
+end module gFTL_Integer32DoubleMap

--- a/src/Integer32Integer32Map.F90
+++ b/src/Integer32Integer32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Integer32MapMod
+module gFTL_Integer32Integer32Map
   use, intrinsic:: iso_fortran_env, only: INT32
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Integer32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Integer32MapMod
+end module gFTL_Integer32Integer32Map

--- a/src/Integer32Integer64Map.F90
+++ b/src/Integer32Integer64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Integer64MapMod
+module gFTL_Integer32Integer64Map
   use, intrinsic:: iso_fortran_env, only: INT32, INT64
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Integer64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Integer64MapMod
+end module gFTL_Integer32Integer64Map

--- a/src/Integer32IntegerMap.F90
+++ b/src/Integer32IntegerMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer32IntegerMapMod
+module gFTL_Integer32IntegerMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32Integer32MapMod, only: Integer32IntegerMap => Integer32Integer32Map
-  use gFTL_Integer32Integer32MapMod, only: Integer32IntegerMapIterator => Integer32Integer32MapIterator
+  use gFTL_Integer32Integer32Map, only: Integer32IntegerMap => Integer32Integer32Map
+  use gFTL_Integer32Integer32Map, only: Integer32IntegerMapIterator => Integer32Integer32MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer32Integer64MapMod, only: Integer32IntegerMap => Integer32Integer64Map
-  use gFTL_Integer32Integer64MapMod, only: Integer32IntegerMapIterator => Integer32Integer64MapIterator
+  use gFTL_Integer32Integer64Map, only: Integer32IntegerMap => Integer32Integer64Map
+  use gFTL_Integer32Integer64Map, only: Integer32IntegerMapIterator => Integer32Integer64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer32IntegerMapMod
 
 #endif
 
-end module gFTL_Integer32IntegerMapMod
+end module gFTL_Integer32IntegerMap

--- a/src/Integer32LogicalMap.F90
+++ b/src/Integer32LogicalMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32LogicalMapMod
+module gFTL_Integer32LogicalMap
   use, intrinsic:: iso_fortran_env, only: INT32
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32LogicalMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32LogicalMapMod
+end module gFTL_Integer32LogicalMap

--- a/src/Integer32Real128Map.F90
+++ b/src/Integer32Real128Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Real128MapMod
+module gFTL_Integer32Real128Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL128
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Real128MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Real128MapMod
+end module gFTL_Integer32Real128Map

--- a/src/Integer32Real32Map.F90
+++ b/src/Integer32Real32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Real32MapMod
+module gFTL_Integer32Real32Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL32
 
 #define _key type(integer(kind=int32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Real32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Real32MapMod
+end module gFTL_Integer32Real32Map

--- a/src/Integer32Real64Map.F90
+++ b/src/Integer32Real64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32Real64MapMod
+module gFTL_Integer32Real64Map
   use, intrinsic:: iso_fortran_env, only: INT32, REAL64
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32Real64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32Real64MapMod
+end module gFTL_Integer32Real64Map

--- a/src/Integer32RealMap.F90
+++ b/src/Integer32RealMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer32RealMapMod
+module gFTL_Integer32RealMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_Integer32Real32MapMod, only: Integer32RealMap => Integer32Real32Map
-  use gFTL_Integer32Real32MapMod, only: Integer32RealMapIterator => Integer32Real32MapIterator
+  use gFTL_Integer32Real32Map, only: Integer32RealMap => Integer32Real32Map
+  use gFTL_Integer32Real32Map, only: Integer32RealMapIterator => Integer32Real32MapIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer32Real64MapMod, only: Integer32RealMap => Integer32Real64Map
-  use gFTL_Integer32Real64MapMod, only: Integer32RealMapIterator => Integer32Real64MapIterator
+  use gFTL_Integer32Real64Map, only: Integer32RealMap => Integer32Real64Map
+  use gFTL_Integer32Real64Map, only: Integer32RealMapIterator => Integer32Real64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer32RealMapMod
 
 #endif
 
-end module gFTL_Integer32RealMapMod
+end module gFTL_Integer32RealMap

--- a/src/Integer32StringMap.F90
+++ b/src/Integer32StringMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32StringMapMod
+module gFTL_Integer32StringMap
   use, intrinsic:: iso_fortran_env, only: INT32
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32StringMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32StringMapMod
+end module gFTL_Integer32StringMap

--- a/src/Integer32UnlimitedMap.F90
+++ b/src/Integer32UnlimitedMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32UnlimitedMapMod
+module gFTL_Integer32UnlimitedMap
   use, intrinsic:: iso_fortran_env, only: INT32
 
 #define _key type(integer(kind=INT32))
@@ -15,4 +15,4 @@ module gFTL_Integer32UnlimitedMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer32UnlimitedMapMod
+end module gFTL_Integer32UnlimitedMap

--- a/src/Integer32Vector.F90
+++ b/src/Integer32Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer32VectorMod
+module gFTL_Integer32Vector
   use, intrinsic :: iso_fortran_env, only: INT32
 
 #define _type type(integer)
@@ -9,4 +9,4 @@ module gFTL_Integer32VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Integer32VectorMod
+end module gFTL_Integer32Vector

--- a/src/Integer64Complex32Map.F90
+++ b/src/Integer64Complex32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64Complex32MapMod
+module gFTL_Integer64Complex32Map
   use, intrinsic:: iso_fortran_env, only: INT64, REAL32
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64Complex32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64Complex32MapMod
+end module gFTL_Integer64Complex32Map

--- a/src/Integer64Complex64Map.F90
+++ b/src/Integer64Complex64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64Complex64MapMod
+module gFTL_Integer64Complex64Map
   use, intrinsic:: iso_fortran_env, only: INT64, REAL64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64Complex64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64Complex64MapMod
+end module gFTL_Integer64Complex64Map

--- a/src/Integer64ComplexMap.F90
+++ b/src/Integer64ComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer64ComplexMapMod
+module gFTL_Integer64ComplexMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_Integer64Complex32MapMod, only: Integer64ComplexMap => Integer64Complex32Map
-  use gFTL_Integer64Complex32MapMod, only: Integer64ComplexMapIterator => Integer32Complex32MapIterator
+  use gFTL_Integer64Complex32Map, only: Integer64ComplexMap => Integer64Complex32Map
+  use gFTL_Integer64Complex32Map, only: Integer64ComplexMapIterator => Integer32Complex32MapIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer64Complex64MapMod, only: Integer64ComplexMap => Integer64Complex64Map
-  use gFTL_Integer64Complex64MapMod, only: Integer64ComplexMapIterator => Integer64Complex64MapIterator
+  use gFTL_Integer64Complex64Map, only: Integer64ComplexMap => Integer64Complex64Map
+  use gFTL_Integer64Complex64Map, only: Integer64ComplexMapIterator => Integer64Complex64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer64ComplexMapMod
 
 #endif
 
-end module gFTL_Integer64ComplexMapMod
+end module gFTL_Integer64ComplexMap

--- a/src/Integer64DoubleComplexMap.F90
+++ b/src/Integer64DoubleComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer64DoubleComplexMapMod
+module gFTL_Integer64DoubleComplexMap
 
 #if _DOUBLE_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Integer64Complex64MapMod, only: Integer64DoubleComplexMap => Integer64Complex64Map
-  use gFTL_Integer64Complex64MapMod, only: Integer64DoubleComplexMapIterator => Integer64Complex64MapIterator
+  use gFTL_Integer64Complex64Map, only: Integer64DoubleComplexMap => Integer64Complex64Map
+  use gFTL_Integer64Complex64Map, only: Integer64DoubleComplexMapIterator => Integer64Complex64MapIterator
 
 #elif _DOUBLE_DEAULT_KIND == _ISO_REAL128
 
-  use gFTL_Integer64Complex128MapMod, only: Integer64DoubleComplexMap => Integer64Complex128Map
-  use gFTL_Integer64Complex128MapMod, only: Integer64DoubleComplexMapIterator => Integer64Complex128MapIterator
+  use gFTL_Integer64Complex128Map, only: Integer64DoubleComplexMap => Integer64Complex128Map
+  use gFTL_Integer64Complex128Map, only: Integer64DoubleComplexMapIterator => Integer64Complex128MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer64DoubleComplexMapMod
 
 #endif
 
-end module gFTL_Integer64DoubleComplexMapMod
+end module gFTL_Integer64DoubleComplexMap

--- a/src/Integer64Integer32Map.F90
+++ b/src/Integer64Integer32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64Integer32MapMod
+module gFTL_Integer64Integer32Map
   use, intrinsic:: iso_fortran_env, only: INT32, INT64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64Integer32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64Integer32MapMod
+end module gFTL_Integer64Integer32Map

--- a/src/Integer64Integer64Map.F90
+++ b/src/Integer64Integer64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64Integer64MapMod
+module gFTL_Integer64Integer64Map
   use, intrinsic:: iso_fortran_env, only: INT64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64Integer64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64Integer64MapMod
+end module gFTL_Integer64Integer64Map

--- a/src/Integer64IntegerMap.F90
+++ b/src/Integer64IntegerMap.F90
@@ -1,14 +1,14 @@
-module gFTL_Integer64IntegerMapMod
+module gFTL_Integer64IntegerMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer64Integer32MapMod, only: Integer64IntegerMap => Integer64Integer32Map
-  use gFTL_Integer64Integer32MapMod, only: Integer64IntegerMapIterator => Integer64Integer32MapIterator
+  use gFTL_Integer64Integer32Map, only: Integer64IntegerMap => Integer64Integer32Map
+  use gFTL_Integer64Integer32Map, only: Integer64IntegerMapIterator => Integer64Integer32MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64Integer64MapMod, only: Integer64IntegerMap => Integer64Integer64Map
-  use gFTL_Integer64Integer64MapMod, only: Integer64IntegerMapIterator => Integer64Integer64MapIterator
+  use gFTL_Integer64Integer64Map, only: Integer64IntegerMap => Integer64Integer64Map
+  use gFTL_Integer64Integer64Map, only: Integer64IntegerMapIterator => Integer64Integer64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_Integer64IntegerMapMod
 
 #endif
 
-end module gFTL_Integer64IntegerMapMod
+end module gFTL_Integer64IntegerMap

--- a/src/Integer64LogicalMap.F90
+++ b/src/Integer64LogicalMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64LogicalMapMod
+module gFTL_Integer64LogicalMap
   use, intrinsic:: iso_fortran_env, only: INT64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64LogicalMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64LogicalMapMod
+end module gFTL_Integer64LogicalMap

--- a/src/Integer64StringMap.F90
+++ b/src/Integer64StringMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64StringMapMod
+module gFTL_Integer64StringMap
   use, intrinsic:: iso_fortran_env, only: INT64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64StringMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64StringMapMod
+end module gFTL_Integer64StringMap

--- a/src/Integer64UnlimitedMap.F90
+++ b/src/Integer64UnlimitedMap.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64UnlimitedMapMod
+module gFTL_Integer64UnlimitedMap
   use, intrinsic:: iso_fortran_env, only: INT64
 
 #define _key type(integer(kind=INT64))
@@ -15,4 +15,4 @@ module gFTL_Integer64UnlimitedMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_Integer64UnlimitedMapMod
+end module gFTL_Integer64UnlimitedMap

--- a/src/Integer64Vector.F90
+++ b/src/Integer64Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Integer64VectorMod
+module gFTL_Integer64Vector
   use, intrinsic :: iso_fortran_env, only: INT64
 
 #define _type type(integer(kind=INT64))
@@ -9,4 +9,4 @@ module gFTL_Integer64VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Integer64VectorMod
+end module gFTL_Integer64Vector

--- a/src/IntegerInteger32Map.F90
+++ b/src/IntegerInteger32Map.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerInteger32MapMod
+module gFTL_IntegerInteger32Map
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32Integer32MapMod, only: IntegerInteger32Map => Integer32Integer32Map
-  use gFTL_Integer32Integer32MapMod, only: IntegerInteger32MapIterator => Integer32Integer32MapIterator
+  use gFTL_Integer32Integer32Map, only: IntegerInteger32Map => Integer32Integer32Map
+  use gFTL_Integer32Integer32Map, only: IntegerInteger32MapIterator => Integer32Integer32MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64Integer32MapMod, only: IntegerInteger32Map => Integer64Integer32Map
-  use gFTL_Integer64Integer32MapMod, only: IntegerInteger32MapIterator => Integer64Integer32MapIterator
+  use gFTL_Integer64Integer32Map, only: IntegerInteger32Map => Integer64Integer32Map
+  use gFTL_Integer64Integer32Map, only: IntegerInteger32MapIterator => Integer64Integer32MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_IntegerInteger32MapMod
 
 #endif
 
-end module gFTL_IntegerInteger32MapMod
+end module gFTL_IntegerInteger32Map

--- a/src/IntegerInteger64Map.F90
+++ b/src/IntegerInteger64Map.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerInteger64MapMod
+module gFTL_IntegerInteger64Map
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32Integer64MapMod, only: IntegerInteger64Map => Integer32Integer64Map
-  use gFTL_Integer32Integer64MapMod, only: IntegerInteger64MapIterator => Integer32Integer64MapIterator
+  use gFTL_Integer32Integer64Map, only: IntegerInteger64Map => Integer32Integer64Map
+  use gFTL_Integer32Integer64Map, only: IntegerInteger64MapIterator => Integer32Integer64MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64Integer64MapMod, only: IntegerInteger64Map => Integer64Integer64Map
-  use gFTL_Integer64Integer64MapMod, only: IntegerInteger64MapIterator => Integer64Integer64MapIterator
+  use gFTL_Integer64Integer64Map, only: IntegerInteger64Map => Integer64Integer64Map
+  use gFTL_Integer64Integer64Map, only: IntegerInteger64MapIterator => Integer64Integer64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_IntegerInteger64MapMod
 
 #endif
 
-end module gFTL_IntegerInteger64MapMod
+end module gFTL_IntegerInteger64Map

--- a/src/IntegerIntegerMap.F90
+++ b/src/IntegerIntegerMap.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerIntegerMapMod
+module gFTL_IntegerIntegerMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32Integer32MapMod, only: IntegerIntegerMap => Integer32Integer32Map
-  use gFTL_Integer32Integer32MapMod, only: IntegerIntegerMapIterator => Integer32Integer32MapIterator
+  use gFTL_Integer32Integer32Map, only: IntegerIntegerMap => Integer32Integer32Map
+  use gFTL_Integer32Integer32Map, only: IntegerIntegerMapIterator => Integer32Integer32MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64Integer64MapMod, only: IntegerIntegerMap => Integer64Integer64Map
-  use gFTL_Integer64Integer64MapMod, only: IntegerIntegerMapIterator => Integer64Integer64MapIterator
+  use gFTL_Integer64Integer64Map, only: IntegerIntegerMap => Integer64Integer64Map
+  use gFTL_Integer64Integer64Map, only: IntegerIntegerMapIterator => Integer64Integer64MapIterator
 
 #else
 
@@ -30,4 +30,4 @@ module gFTL_IntegerIntegerMapMod
 
 #endif
 
-end module gFTL_IntegerIntegerMapMod
+end module gFTL_IntegerIntegerMap

--- a/src/IntegerLogicalMap.F90
+++ b/src/IntegerLogicalMap.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerLogicalMapMod
+module gFTL_IntegerLogicalMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32LogicalMapMod, only: IntegerLogicalMap => Integer32LogicalMap
-  use gFTL_Integer32LogicalMapMod, only: IntegerLogicalMapIterator => Integer32LogicalMapIterator
+  use gFTL_Integer32LogicalMap, only: IntegerLogicalMap => Integer32LogicalMap
+  use gFTL_Integer32LogicalMap, only: IntegerLogicalMapIterator => Integer32LogicalMapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64LogicalMapMod, only: IntegerLogicalMap => Integer64LogicalMap
-  use gFTL_Integer64LogicalMapMod, only: IntegerLogicalMapIterator => Integer64LogicalMapIterator
+  use gFTL_Integer64LogicalMap, only: IntegerLogicalMap => Integer64LogicalMap
+  use gFTL_Integer64LogicalMap, only: IntegerLogicalMapIterator => Integer64LogicalMapIterator
 
 #else
 
@@ -28,4 +28,4 @@ module gFTL_IntegerLogicalMapMod
 
 #endif
 
-end module gFTL_IntegerLogicalMapMod
+end module gFTL_IntegerLogicalMap

--- a/src/IntegerStringMap.F90
+++ b/src/IntegerStringMap.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerStringMapMod
+module gFTL_IntegerStringMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32StringMapMod, only: IntegerStringMap => Integer32StringMap
-  use gFTL_Integer32StringMapMod, only: IntegerStringMapIterator => Integer32StringMapIterator
+  use gFTL_Integer32StringMap, only: IntegerStringMap => Integer32StringMap
+  use gFTL_Integer32StringMap, only: IntegerStringMapIterator => Integer32StringMapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64StringMapMod, only: IntegerStringMap => Integer64StringMap
-  use gFTL_Integer64StringMapMod, only: IntegerStringMapIterator => Integer64StringMapIterator
+  use gFTL_Integer64StringMap, only: IntegerStringMap => Integer64StringMap
+  use gFTL_Integer64StringMap, only: IntegerStringMapIterator => Integer64StringMapIterator
 
 #else
 
@@ -29,4 +29,4 @@ module gFTL_IntegerStringMapMod
 
 #endif
 
-end module gFTL_IntegerStringMapMod
+end module gFTL_IntegerStringMap

--- a/src/IntegerUnlimitedMap.F90
+++ b/src/IntegerUnlimitedMap.F90
@@ -1,14 +1,14 @@
-module gFTL_IntegerUnlimitedMapMod
+module gFTL_IntegerUnlimitedMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32UnlimitedMapMod, only: IntegerUnlimitedMap => Integer32UnlimitedMap
-  use gFTL_Integer32UnlimitedMapMod, only: IntegerUnlimitedMapIterator => Integer32UnlimitedMapIterator
+  use gFTL_Integer32UnlimitedMap, only: IntegerUnlimitedMap => Integer32UnlimitedMap
+  use gFTL_Integer32UnlimitedMap, only: IntegerUnlimitedMapIterator => Integer32UnlimitedMapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_Integer64UnlimitedMapMod, only: IntegerUnlimitedMap => Integer64UnlimitedMap
-  use gFTL_Integer64UnlimitedMapMod, only: IntegerUnlimitedMapIterator => Integer64UnlimitedMapIterator
+  use gFTL_Integer64UnlimitedMap, only: IntegerUnlimitedMap => Integer64UnlimitedMap
+  use gFTL_Integer64UnlimitedMap, only: IntegerUnlimitedMapIterator => Integer64UnlimitedMapIterator
 
 #else
 
@@ -29,4 +29,4 @@ module gFTL_IntegerUnlimitedMapMod
 
 #endif
 
-end module gFTL_IntegerUnlimitedMapMod
+end module gFTL_IntegerUnlimitedMap

--- a/src/IntegerVector.F90
+++ b/src/IntegerVector.F90
@@ -1,13 +1,13 @@
-module gFTL_IntegerVectorMod
+module gFTL_IntegerVector
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_Integer32VectorMod, only: IntegerVector => Integer32Vector
-  use gFTL_Integer32VectorMod, only: IntegerVectorIterator => Integer32VectorIterator
+  use gFTL_Integer32Vector, only: IntegerVector => Integer32Vector
+  use gFTL_Integer32Vector, only: IntegerVectorIterator => Integer32VectorIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
-  use gFTL_Integer64VectorMod, only: IntegerVector => Integer64Vector
-  use gFTL_Integer64VectorMod, only: IntegerVectorIterator => Integer64VectorIterator
+  use gFTL_Integer64Vector, only: IntegerVector => Integer64Vector
+  use gFTL_Integer64Vector, only: IntegerVectorIterator => Integer64VectorIterator
 
 #else
 
@@ -21,4 +21,4 @@ module gFTL_IntegerVectorMod
 
 #endif
 
-end module gFTL_IntegerVectorMod
+end module gFTL_IntegerVector

--- a/src/LogicalVector.F90
+++ b/src/LogicalVector.F90
@@ -1,4 +1,4 @@
-module gFTL_LogicalVectorMod
+module gFTL_LogicalVector
 
 #define _type type(logical)
 #define _vector LogicalVector
@@ -8,4 +8,4 @@ module gFTL_LogicalVectorMod
 #undef _vector
 #undef _type
 
-end module gFTL_LogicalVectorMod
+end module gFTL_LogicalVector

--- a/src/Real128Vector.F90
+++ b/src/Real128Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Real128VectorMod
+module gFTL_Real128Vector
   use, intrinsic :: iso_fortran_env, only: REAL128
 
 #define _type type(real(kind=REAL128))
@@ -9,4 +9,4 @@ module gFTL_Real128VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Real128VectorMod
+end module gFTL_Real128Vector

--- a/src/Real32Vector.F90
+++ b/src/Real32Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Real32VectorMod
+module gFTL_Real32Vector
   use, intrinsic :: iso_fortran_env, only: REAL32
 
 #define _type type(real(kind=REAL32))
@@ -9,4 +9,4 @@ module gFTL_Real32VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Real32VectorMod
+end module gFTL_Real32Vector

--- a/src/Real64Vector.F90
+++ b/src/Real64Vector.F90
@@ -1,4 +1,4 @@
-module gFTL_Real64VectorMod
+module gFTL_Real64Vector
   use, intrinsic :: iso_fortran_env, only: REAL64
 
 #define _type type(real(kind=REAL64))
@@ -9,4 +9,4 @@ module gFTL_Real64VectorMod
 #undef _vector
 #undef _type
   
-end module gFTL_Real64VectorMod
+end module gFTL_Real64Vector

--- a/src/RealVector.F90
+++ b/src/RealVector.F90
@@ -1,14 +1,14 @@
-module gFTL_RealVectorMod
+module gFTL_RealVector
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_Real32VectorMod, only: RealVector => Real32Vector
-  use gFTL_Real32VectorMod, only: RealVectorIterator => Real32VectorIterator
+  use gFTL_Real32Vector, only: RealVector => Real32Vector
+  use gFTL_Real32Vector, only: RealVectorIterator => Real32VectorIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_Real64VectorMod, only: RealVector => Real64Vector
-  use gFTL_Real64VectorMod, only: RealVectorIterator => Real64VectorIterator
+  use gFTL_Real64Vector, only: RealVector => Real64Vector
+  use gFTL_Real64Vector, only: RealVectorIterator => Real64VectorIterator
 
 #else
 
@@ -22,4 +22,4 @@ module gFTL_RealVectorMod
 
 #endif
   
-end module gFTL_RealVectorMod
+end module gFTL_RealVector

--- a/src/StringComplex128Map.F90
+++ b/src/StringComplex128Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringComplex128MapMod
+module gFTL_StringComplex128Map
   use, intrinsic:: iso_fortran_env, only: REAL128
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringComplex128MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringComplex128MapMod
+end module gFTL_StringComplex128Map

--- a/src/StringComplex32Map.F90
+++ b/src/StringComplex32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringComplex32MapMod
+module gFTL_StringComplex32Map
   use, intrinsic:: iso_fortran_env, only: REAL32
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringComplex32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringComplex32MapMod
+end module gFTL_StringComplex32Map

--- a/src/StringComplex64Map.F90
+++ b/src/StringComplex64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringComplex64MapMod
+module gFTL_StringComplex64Map
   use, intrinsic:: iso_fortran_env, only: REAL64
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringComplex64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringComplex64MapMod
+end module gFTL_StringComplex64Map

--- a/src/StringComplexMap.F90
+++ b/src/StringComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_StringComplexMapMod
+module gFTL_StringComplexMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_StringComplex32MapMod, only: StringComplexMap => StringComplex32Map
-  use gFTL_StringComplex32MapMod, only: StringComplexMapIterator => StringComplex32MapIterator
+  use gFTL_StringComplex32Map, only: StringComplexMap => StringComplex32Map
+  use gFTL_StringComplex32Map, only: StringComplexMapIterator => StringComplex32MapIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_StringComplex64MapMod, only: StringComplexMap => StringComplex64Map
-  use gFTL_StringComplex64MapMod, only: StringComplexMapIterator => StringComplex64MapIterator
+  use gFTL_StringComplex64Map, only: StringComplexMap => StringComplex64Map
+  use gFTL_StringComplex64Map, only: StringComplexMapIterator => StringComplex64MapIterator
 
 #else
   
@@ -29,4 +29,4 @@ module gFTL_StringComplexMapMod
 
 #endif
 
-end module gFTL_StringComplexMapMod
+end module gFTL_StringComplexMap

--- a/src/StringDoubleComplexMap.F90
+++ b/src/StringDoubleComplexMap.F90
@@ -1,14 +1,14 @@
-module gFTL_StringDoubleComplexMapMod
+module gFTL_StringDoubleComplexMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_StringDoubleComplex64MapMod, only: StringDoubleComplexMap => StringComplex64Map
-  use gFTL_StringDoubleComplex64MapMod, only: StringDoubleComplexMapIterator => StringComplex64MapIterator
+  use gFTL_StringDoubleComplex64Map, only: StringDoubleComplexMap => StringComplex64Map
+  use gFTL_StringDoubleComplex64Map, only: StringDoubleComplexMapIterator => StringComplex64MapIterator
 
 #elif defined(_ISO_REAL128) && (_DOUBLE_DEAULT_KIND == _ISO_REAL128)
 
-  use gFTL_StringDoubleComplex128MapMod, only: StringDoubleComplexMap => StringComplex128Map
-  use gFTL_StringDoubleComplex128MapMod, only: StringDoubleComplexMapIterator => StringComplex128MapIterator
+  use gFTL_StringDoubleComplex128Map, only: StringDoubleComplexMap => StringComplex128Map
+  use gFTL_StringDoubleComplex128Map, only: StringDoubleComplexMapIterator => StringComplex128MapIterator
 #else
   
  
@@ -28,4 +28,4 @@ module gFTL_StringDoubleComplexMapMod
 
 #endif
 
-end module gFTL_StringDoubleComplexMapMod
+end module gFTL_StringDoubleComplexMap

--- a/src/StringDoubleMap.F90
+++ b/src/StringDoubleMap.F90
@@ -1,14 +1,14 @@
-module gFTL_StringDoubleMapMod
+module gFTL_StringDoubleMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_StringDouble64MapMod, only: StringDoubleMap => StringReal64Map
-  use gFTL_StringDouble64MapMod, only: StringDoubleMapIterator => StringReal64MapIterator
+  use gFTL_StringDouble64Map, only: StringDoubleMap => StringReal64Map
+  use gFTL_StringDouble64Map, only: StringDoubleMapIterator => StringReal64MapIterator
 
 #elif defined(_ISO_REAL128) && (_DOUBLE_DEAULT_KIND == _ISO_REAL128)
 
-  use gFTL_StringDouble128MapMod, only: StringDoubleMap => StringReal128Map
-  use gFTL_StringDouble128MapMod, only: StringDoubleMapIterator => StringReal128MapIterator
+  use gFTL_StringDouble128Map, only: StringDoubleMap => StringReal128Map
+  use gFTL_StringDouble128Map, only: StringDoubleMapIterator => StringReal128MapIterator
 #else
   
  
@@ -28,4 +28,4 @@ module gFTL_StringDoubleMapMod
 
 #endif
 
-end module gFTL_StringDoubleMapMod
+end module gFTL_StringDoubleMap

--- a/src/StringInteger32Map.F90
+++ b/src/StringInteger32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringInteger32MapMod
+module gFTL_StringInteger32Map
   use, intrinsic:: iso_fortran_env, only: INT32
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringInteger32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringInteger32MapMod
+end module gFTL_StringInteger32Map

--- a/src/StringInteger64Map.F90
+++ b/src/StringInteger64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringInteger64MapMod
+module gFTL_StringInteger64Map
   use, intrinsic:: iso_fortran_env, only: INT64
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringInteger64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringInteger64MapMod
+end module gFTL_StringInteger64Map

--- a/src/StringIntegerMap.F90
+++ b/src/StringIntegerMap.F90
@@ -1,14 +1,14 @@
-module gFTL_StringIntegerMapMod
+module gFTL_StringIntegerMap
 
 #if _INT_DEAULT_KIND == _ISO_INT32
 
-  use gFTL_StringInteger32MapMod, only: StringIntegerMap => StringInteger32Map
-  use gFTL_StringInteger32MapMod, only: StringIntegerMapIterator => StringInteger32MapIterator
+  use gFTL_StringInteger32Map, only: StringIntegerMap => StringInteger32Map
+  use gFTL_StringInteger32Map, only: StringIntegerMapIterator => StringInteger32MapIterator
 
 #elif _INT_DEAULT_KIND == _ISO_INT64
 
-  use gFTL_StringInteger64MapMod, only: StringIntegerMap => StringInteger64Map
-  use gFTL_StringInteger64MapMod, only: StringIntegerMapIterator => StringInteger64MapIterator
+  use gFTL_StringInteger64Map, only: StringIntegerMap => StringInteger64Map
+  use gFTL_StringInteger64Map, only: StringIntegerMapIterator => StringInteger64MapIterator
 
 #else
   
@@ -29,4 +29,4 @@ module gFTL_StringIntegerMapMod
 
 #endif
 
-end module gFTL_StringIntegerMapMod
+end module gFTL_StringIntegerMap

--- a/src/StringLogicalMap.F90
+++ b/src/StringLogicalMap.F90
@@ -1,4 +1,4 @@
-module gFTL_StringLogicalMapMod
+module gFTL_StringLogicalMap
 
 #include "types/key_deferredLengthString.inc"
 #define _value type(logical)
@@ -14,4 +14,4 @@ module gFTL_StringLogicalMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringLogicalMapMod
+end module gFTL_StringLogicalMap

--- a/src/StringReal128Map.F90
+++ b/src/StringReal128Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringReal128MapMod
+module gFTL_StringReal128Map
   use, intrinsic:: iso_fortran_env, only: REAL128
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringReal128MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringReal128MapMod
+end module gFTL_StringReal128Map

--- a/src/StringReal32Map.F90
+++ b/src/StringReal32Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringReal32MapMod
+module gFTL_StringReal32Map
   use, intrinsic:: iso_fortran_env, only: REAL32
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringReal32MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringReal32MapMod
+end module gFTL_StringReal32Map

--- a/src/StringReal64Map.F90
+++ b/src/StringReal64Map.F90
@@ -1,4 +1,4 @@
-module gFTL_StringReal64MapMod
+module gFTL_StringReal64Map
   use, intrinsic:: iso_fortran_env, only: REAL64
 
 #include "types/key_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringReal64MapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringReal64MapMod
+end module gFTL_StringReal64Map

--- a/src/StringRealMap.F90
+++ b/src/StringRealMap.F90
@@ -1,14 +1,14 @@
-module gFTL_StringRealMapMod
+module gFTL_StringRealMap
 
 #if _REAL_DEAULT_KIND == _ISO_REAL32
 
-  use gFTL_StringReal32MapMod, only: StringRealMap => StringReal32Map
-  use gFTL_StringReal32MapMod, only: StringRealMapIterator => StringReal32MapIterator
+  use gFTL_StringReal32Map, only: StringRealMap => StringReal32Map
+  use gFTL_StringReal32Map, only: StringRealMapIterator => StringReal32MapIterator
 
 #elif _REAL_DEAULT_KIND == _ISO_REAL64
 
-  use gFTL_StringReal64MapMod, only: StringRealMap => StringReal64Map
-  use gFTL_StringReal64MapMod, only: StringRealMapIterator => StringReal64MapIterator
+  use gFTL_StringReal64Map, only: StringRealMap => StringReal64Map
+  use gFTL_StringReal64Map, only: StringRealMapIterator => StringReal64MapIterator
 
 #else
    
@@ -28,4 +28,4 @@ module gFTL_StringRealMapMod
 
 #endif
 
-end module gFTL_StringRealMapMod
+end module gFTL_StringRealMap

--- a/src/StringStringMap.F90
+++ b/src/StringStringMap.F90
@@ -1,4 +1,4 @@
-module gFTL_StringStringMapMod
+module gFTL_StringStringMap
 
 #include "types/key_deferredLengthString.inc"
 #include "types/value_deferredLengthString.inc"
@@ -15,4 +15,4 @@ module gFTL_StringStringMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringStringMapMod
+end module gFTL_StringStringMap

--- a/src/StringUnlimitedMap.F90
+++ b/src/StringUnlimitedMap.F90
@@ -1,4 +1,4 @@
-module gFTL_StringUnlimitedMapMod
+module gFTL_StringUnlimitedMap
 
 #include "types/key_deferredLengthString.inc"
 #include "types/value_unlimitedPoly.inc"
@@ -15,4 +15,4 @@ module gFTL_StringUnlimitedMapMod
 #undef _value
 #undef _key  
 
-end module gFTL_StringUnlimitedMapMod
+end module gFTL_StringUnlimitedMap

--- a/src/StringVector.F90
+++ b/src/StringVector.F90
@@ -1,4 +1,4 @@
-module gFTL_StringVectorMod
+module gFTL_StringVector
 
 #  include "types/deferredLengthString.inc"
 #define _vector StringVector
@@ -8,4 +8,4 @@ module gFTL_StringVectorMod
 #undef _vector
 #undef _type
 
-end module gFTL_StringVectorMod
+end module gFTL_StringVector

--- a/src/UnlimitedVector.F90
+++ b/src/UnlimitedVector.F90
@@ -1,4 +1,4 @@
-module gFTL_UnlimitedVectorMod
+module gFTL_UnlimitedVector
 
 #  include "types/unlimitedPoly.inc"
 #define _vector UnlimitedVector
@@ -8,4 +8,4 @@ module gFTL_UnlimitedVectorMod
 #undef _vector
 #undef _type
 
-end module gFTL_UnlimitedVectorMod
+end module gFTL_UnlimitedVector


### PR DESCRIPTION
I have decided that module suffixes generally serve no purpose and
inconsistent styles between projects ("m_Foo", "Foo_mod", "FooMod") is
a source of tedious issues.

Note that suffixes were never used to distinguishe subroutines,
functions, and main programs prior to F90.  So why does a new type of
program unit need them?     Granted, some suffix/prefix is often
needed to distinguish a module from the derived type name that is
defined within, but package _prefixes_ are much better for preventing
name collisions.