### PR TITLE
Swap CMake module path order for better superproject support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if (POLICY CMP0076)
 endif()
 
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${GFTL_SHARED_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${GFTL_SHARED_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(${CMAKE_Fortran_COMPILER_ID} RESULT_VARIABLE found)
 include(check_intrinsic_kinds RESULT_VARIABLE found)
 


### PR DESCRIPTION
Hi everyone,

This is a small PR that changes the position of gFTL-shared's CMake module directory in `CMAKE_MODULE_PATH`. Currently gFTL-shared's module directory is *appended* to `CMAKE_MODULE_PATH` before the `include()` call that sets compiler flags:

https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/blob/8b8e8e8d3e68f612aa73b7796958c75b0d3d7b4f/CMakeLists.txt#L32-L33

I'd propose `${GFTL_SHARED_SOURCE_DIR}/cmake` be put at the front of `CMAKE_MODULE_PATH` instead so `${CMAKE_Fortran_COMPILER_ID}.cmake` modules from other projects (e.g. ESMA_cmake) aren't wrongfully included when gFTL-shared is build as a subtree of superprojects. I believe this is safe because of CMake's scoping rules (i.e.  `CMAKE_MODULE_PATH` of super directories aren't affected). I think this change is useful to other superprojects that want to build gFTL-shared as a subtree hence the PR. What do you think?

Liam