### PR TITLE
Rename pair types within maps to have type-specific names

### DIFF
--- a/src/Integer32Complex128Map.F90
+++ b/src/Integer32Complex128Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Complex128Map
 #define _value type(complex(kind=REAL128))
 #define _map Integer32Complex128Map
 #define _iterator Integer32Complex128MapIterator
+#define _pair Integer32Complex128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Complex128Map.F90
+++ b/src/Integer32Complex128Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Complex128Map
 #define _value type(complex(kind=REAL128))
 #define _map Integer32Complex128Map
 #define _iterator Integer32Complex128MapIterator
-#define _pair Integer32Complex128MapPair
+#define _pair Integer32Complex128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Complex32Map.F90
+++ b/src/Integer32Complex32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Complex32Map
 #define _value type(complex(kind=REAL32))
 #define _map Integer32Complex32Map
 #define _iterator Integer32Complex32MapIterator
+#define _pair Integer32Complex32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Complex32Map.F90
+++ b/src/Integer32Complex32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Complex32Map
 #define _value type(complex(kind=REAL32))
 #define _map Integer32Complex32Map
 #define _iterator Integer32Complex32MapIterator
-#define _pair Integer32Complex32MapPair
+#define _pair Integer32Complex32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Complex64Map.F90
+++ b/src/Integer32Complex64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Complex64Map
 #define _value type(complex(kind=REAL64))
 #define _map Integer32Complex64Map
 #define _iterator Integer32Complex64MapIterator
-#define _pair Integer32Complex64MapPair
+#define _pair Integer32Complex64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Complex64Map.F90
+++ b/src/Integer32Complex64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Complex64Map
 #define _value type(complex(kind=REAL64))
 #define _map Integer32Complex64Map
 #define _iterator Integer32Complex64MapIterator
+#define _pair Integer32Complex64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32ComplexMap.F90
+++ b/src/Integer32ComplexMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer32ComplexMap
 #  define _value type(complex)
 #  define _map Integer32ComplexMap
 #  define _iterator Integer32ComplexMapIterator
-#  define _pair Integer32ComplexMapPair
+#  define _pair Integer32ComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32ComplexMap.F90
+++ b/src/Integer32ComplexMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer32ComplexMap
 #  define _value type(complex)
 #  define _map Integer32ComplexMap
 #  define _iterator Integer32ComplexMapIterator
+#  define _pair Integer32ComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32DoubleComplexMap.F90
+++ b/src/Integer32DoubleComplexMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer32DoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map Integer32DoubleComplexMap
 #  define _iterator Integer32DoubleComplexMapIterator
+#  define _pair Integer32DoubleComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32DoubleComplexMap.F90
+++ b/src/Integer32DoubleComplexMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer32DoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map Integer32DoubleComplexMap
 #  define _iterator Integer32DoubleComplexMapIterator
-#  define _pair Integer32DoubleComplexMapPair
+#  define _pair Integer32DoubleComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32DoubleMap.F90
+++ b/src/Integer32DoubleMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer32DoubleMap
 #  define _value type(double precision)
 #  define _map Integer32DoubleMap
 #  define _iterator Integer32DoubleMapIterator
-#  define _pair Integer32DoubleMapPair
+#  define _pair Integer32DoublePair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32DoubleMap.F90
+++ b/src/Integer32DoubleMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer32DoubleMap
 #  define _value type(double precision)
 #  define _map Integer32DoubleMap
 #  define _iterator Integer32DoubleMapIterator
+#  define _pair Integer32DoubleMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32Integer32Map.F90
+++ b/src/Integer32Integer32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Integer32Map
 #define _value type(integer(kind=INT32))
 #define _map Integer32Integer32Map
 #define _iterator Integer32Integer32MapIterator
-#define _pair Integer32Integer32MapPair
+#define _pair Integer32Integer32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Integer32Map.F90
+++ b/src/Integer32Integer32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Integer32Map
 #define _value type(integer(kind=INT32))
 #define _map Integer32Integer32Map
 #define _iterator Integer32Integer32MapIterator
+#define _pair Integer32Integer32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Integer64Map.F90
+++ b/src/Integer32Integer64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Integer64Map
 #define _value type(integer(kind=INT64))
 #define _map Integer32Integer64Map
 #define _iterator Integer32Integer64MapIterator
+#define _pair Integer32Integer64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Integer64Map.F90
+++ b/src/Integer32Integer64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Integer64Map
 #define _value type(integer(kind=INT64))
 #define _map Integer32Integer64Map
 #define _iterator Integer32Integer64MapIterator
-#define _pair Integer32Integer64MapPair
+#define _pair Integer32Integer64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32IntegerMap.F90
+++ b/src/Integer32IntegerMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer32IntegerMap
 #  define _value type(integer)
 #  define _map Integer32IntegerMap
 #  define _iterator Integer32IntegerMapIterator
+#  define _pair Integer32IntegerMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32IntegerMap.F90
+++ b/src/Integer32IntegerMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer32IntegerMap
 #  define _value type(integer)
 #  define _map Integer32IntegerMap
 #  define _iterator Integer32IntegerMapIterator
-#  define _pair Integer32IntegerMapPair
+#  define _pair Integer32IntegerPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32LogicalMap.F90
+++ b/src/Integer32LogicalMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32LogicalMap
 #define _value type(logical)
 #define _map Integer32LogicalMap
 #define _iterator Integer32LogicalMapIterator
-#define _pair Integer32LogicalMapPair
+#define _pair Integer32LogicalPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32LogicalMap.F90
+++ b/src/Integer32LogicalMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32LogicalMap
 #define _value type(logical)
 #define _map Integer32LogicalMap
 #define _iterator Integer32LogicalMapIterator
+#define _pair Integer32LogicalMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real128Map.F90
+++ b/src/Integer32Real128Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Real128Map
 #define _value type(real(kind=REAL128))
 #define _map Integer32Real128Map
 #define _iterator Integer32Real128MapIterator
-#define _pair Integer32Real128MapPair
+#define _pair Integer32Real128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real128Map.F90
+++ b/src/Integer32Real128Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Real128Map
 #define _value type(real(kind=REAL128))
 #define _map Integer32Real128Map
 #define _iterator Integer32Real128MapIterator
+#define _pair Integer32Real128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real32Map.F90
+++ b/src/Integer32Real32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Real32Map
 #define _value type(real(kind=REAL32))
 #define _map Integer32Real32Map
 #define _iterator Integer32Real32MapIterator
+#define _pair Integer32Real32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real32Map.F90
+++ b/src/Integer32Real32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Real32Map
 #define _value type(real(kind=REAL32))
 #define _map Integer32Real32Map
 #define _iterator Integer32Real32MapIterator
-#define _pair Integer32Real32MapPair
+#define _pair Integer32Real32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real64Map.F90
+++ b/src/Integer32Real64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32Real64Map
 #define _value type(real(kind=REAL64))
 #define _map Integer32Real64Map
 #define _iterator Integer32Real64MapIterator
-#define _pair Integer32Real64MapPair
+#define _pair Integer32Real64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32Real64Map.F90
+++ b/src/Integer32Real64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32Real64Map
 #define _value type(real(kind=REAL64))
 #define _map Integer32Real64Map
 #define _iterator Integer32Real64MapIterator
+#define _pair Integer32Real64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32RealMap.F90
+++ b/src/Integer32RealMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer32RealMap
 #  define _value type(real)
 #  define _map Integer32RealMap
 #  define _iterator Integer32RealMapIterator
+#  define _pair Integer32RealMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32RealMap.F90
+++ b/src/Integer32RealMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer32RealMap
 #  define _value type(real)
 #  define _map Integer32RealMap
 #  define _iterator Integer32RealMapIterator
-#  define _pair Integer32RealMapPair
+#  define _pair Integer32RealPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer32StringMap.F90
+++ b/src/Integer32StringMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32StringMap
 #include "types/value_deferredLengthString.inc"
 #define _map Integer32StringMap
 #define _iterator Integer32StringMapIterator
+#define _pair Integer32StringMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32StringMap.F90
+++ b/src/Integer32StringMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32StringMap
 #include "types/value_deferredLengthString.inc"
 #define _map Integer32StringMap
 #define _iterator Integer32StringMapIterator
-#define _pair Integer32StringMapPair
+#define _pair Integer32StringPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32UnlimitedMap.F90
+++ b/src/Integer32UnlimitedMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer32UnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map Integer32UnlimitedMap
 #define _iterator Integer32UnlimitedMapIterator
+#define _pair Integer32UnlimitedMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer32UnlimitedMap.F90
+++ b/src/Integer32UnlimitedMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer32UnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map Integer32UnlimitedMap
 #define _iterator Integer32UnlimitedMapIterator
-#define _pair Integer32UnlimitedMapPair
+#define _pair Integer32UnlimitedPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex128Map.F90
+++ b/src/Integer64Complex128Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Complex128Map
 #define _value type(complex(kind=REAL128))
 #define _map Integer64Complex128Map
 #define _iterator Integer64Complex128MapIterator
-#define _pair Integer64Complex128MapPair
+#define _pair Integer64Complex128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex128Map.F90
+++ b/src/Integer64Complex128Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Complex128Map
 #define _value type(complex(kind=REAL128))
 #define _map Integer64Complex128Map
 #define _iterator Integer64Complex128MapIterator
+#define _pair Integer64Complex128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex32Map.F90
+++ b/src/Integer64Complex32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Complex32Map
 #define _value type(complex(kind=REAL32))
 #define _map Integer64Complex32Map
 #define _iterator Integer64Complex32MapIterator
+#define _pair Integer64Complex32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex32Map.F90
+++ b/src/Integer64Complex32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Complex32Map
 #define _value type(complex(kind=REAL32))
 #define _map Integer64Complex32Map
 #define _iterator Integer64Complex32MapIterator
-#define _pair Integer64Complex32MapPair
+#define _pair Integer64Complex32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex64Map.F90
+++ b/src/Integer64Complex64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Complex64Map
 #define _value type(complex(kind=REAL64))
 #define _map Integer64Complex64Map
 #define _iterator Integer64Complex64MapIterator
-#define _pair Integer64Complex64MapPair
+#define _pair Integer64Complex64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Complex64Map.F90
+++ b/src/Integer64Complex64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Complex64Map
 #define _value type(complex(kind=REAL64))
 #define _map Integer64Complex64Map
 #define _iterator Integer64Complex64MapIterator
+#define _pair Integer64Complex64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64ComplexMap.F90
+++ b/src/Integer64ComplexMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer64ComplexMap
 #  define _value type(complex)
 #  define _map Integer64ComplexMap
 #  define _iterator Integer64ComplexMapIterator
-#  define _pair Integer64ComplexMapPair
+#  define _pair Integer64ComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64ComplexMap.F90
+++ b/src/Integer64ComplexMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer64ComplexMap
 #  define _value type(complex)
 #  define _map Integer64ComplexMap
 #  define _iterator Integer64ComplexMapIterator
+#  define _pair Integer64ComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64DoubleComplexMap.F90
+++ b/src/Integer64DoubleComplexMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer64DoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map Integer64DoubleComplexMap
 #  define _iterator Integer64DoubleComplexMapIterator
-#  define _pair Integer64DoubleComplexMapPair
+#  define _pair Integer64DoubleComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64DoubleComplexMap.F90
+++ b/src/Integer64DoubleComplexMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer64DoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map Integer64DoubleComplexMap
 #  define _iterator Integer64DoubleComplexMapIterator
+#  define _pair Integer64DoubleComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64DoubleMap.F90
+++ b/src/Integer64DoubleMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer64DoubleMap
 #  define _value type(double precision)
 #  define _map Integer64DoubleMap
 #  define _iterator Integer64DoubleMapIterator
+#  define _pair Integer64DoubleMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64DoubleMap.F90
+++ b/src/Integer64DoubleMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer64DoubleMap
 #  define _value type(double precision)
 #  define _map Integer64DoubleMap
 #  define _iterator Integer64DoubleMapIterator
-#  define _pair Integer64DoubleMapPair
+#  define _pair Integer64DoublePair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64Integer32Map.F90
+++ b/src/Integer64Integer32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Integer32Map
 #define _value type(integer(kind=INT32))
 #define _map Integer64Integer32Map
 #define _iterator Integer64Integer32MapIterator
+#define _pair Integer64Integer32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Integer32Map.F90
+++ b/src/Integer64Integer32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Integer32Map
 #define _value type(integer(kind=INT32))
 #define _map Integer64Integer32Map
 #define _iterator Integer64Integer32MapIterator
-#define _pair Integer64Integer32MapPair
+#define _pair Integer64Integer32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Integer64Map.F90
+++ b/src/Integer64Integer64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Integer64Map
 #define _value type(integer(kind=INT64))
 #define _map Integer64Integer64Map
 #define _iterator Integer64Integer64MapIterator
-#define _pair Integer64Integer64MapPair
+#define _pair Integer64Integer64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Integer64Map.F90
+++ b/src/Integer64Integer64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Integer64Map
 #define _value type(integer(kind=INT64))
 #define _map Integer64Integer64Map
 #define _iterator Integer64Integer64MapIterator
+#define _pair Integer64Integer64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64IntegerMap.F90
+++ b/src/Integer64IntegerMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer64IntegerMap
 #  define _value type(integer)
 #  define _map Integer64IntegerMap
 #  define _iterator Integer64IntegerMapIterator
-#  define _pair Integer64IntegerMapPair
+#  define _pair Integer64IntegerPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64IntegerMap.F90
+++ b/src/Integer64IntegerMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer64IntegerMap
 #  define _value type(integer)
 #  define _map Integer64IntegerMap
 #  define _iterator Integer64IntegerMapIterator
+#  define _pair Integer64IntegerMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64LogicalMap.F90
+++ b/src/Integer64LogicalMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64LogicalMap
 #define _value type(logical)
 #define _map Integer64LogicalMap
 #define _iterator Integer64LogicalMapIterator
+#define _pair Integer64LogicalMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64LogicalMap.F90
+++ b/src/Integer64LogicalMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64LogicalMap
 #define _value type(logical)
 #define _map Integer64LogicalMap
 #define _iterator Integer64LogicalMapIterator
-#define _pair Integer64LogicalMapPair
+#define _pair Integer64LogicalPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real128Map.F90
+++ b/src/Integer64Real128Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Real128Map
 #define _value type(real(kind=REAL128))
 #define _map Integer64Real128Map
 #define _iterator Integer64Real128MapIterator
+#define _pair Integer64Real128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real128Map.F90
+++ b/src/Integer64Real128Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Real128Map
 #define _value type(real(kind=REAL128))
 #define _map Integer64Real128Map
 #define _iterator Integer64Real128MapIterator
-#define _pair Integer64Real128MapPair
+#define _pair Integer64Real128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real32Map.F90
+++ b/src/Integer64Real32Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Real32Map
 #define _value type(real(kind=REAL32))
 #define _map Integer64Real32Map
 #define _iterator Integer64Real32MapIterator
+#define _pair Integer64Real32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real32Map.F90
+++ b/src/Integer64Real32Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Real32Map
 #define _value type(real(kind=REAL32))
 #define _map Integer64Real32Map
 #define _iterator Integer64Real32MapIterator
-#define _pair Integer64Real32MapPair
+#define _pair Integer64Real32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real64Map.F90
+++ b/src/Integer64Real64Map.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64Real64Map
 #define _value type(real(kind=REAL64))
 #define _map Integer64Real64Map
 #define _iterator Integer64Real64MapIterator
+#define _pair Integer64Real64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64Real64Map.F90
+++ b/src/Integer64Real64Map.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64Real64Map
 #define _value type(real(kind=REAL64))
 #define _map Integer64Real64Map
 #define _iterator Integer64Real64MapIterator
-#define _pair Integer64Real64MapPair
+#define _pair Integer64Real64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64RealMap.F90
+++ b/src/Integer64RealMap.F90
@@ -18,6 +18,7 @@ module gFTL_Integer64RealMap
 #  define _value type(real)
 #  define _map Integer64RealMap
 #  define _iterator Integer64RealMapIterator
+#  define _pair Integer64RealMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64RealMap.F90
+++ b/src/Integer64RealMap.F90
@@ -18,7 +18,7 @@ module gFTL_Integer64RealMap
 #  define _value type(real)
 #  define _map Integer64RealMap
 #  define _iterator Integer64RealMapIterator
-#  define _pair Integer64RealMapPair
+#  define _pair Integer64RealPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/Integer64StringMap.F90
+++ b/src/Integer64StringMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64StringMap
 #include "types/value_deferredLengthString.inc"
 #define _map Integer64StringMap
 #define _iterator Integer64StringMapIterator
-#define _pair Integer64StringMapPair
+#define _pair Integer64StringPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64StringMap.F90
+++ b/src/Integer64StringMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64StringMap
 #include "types/value_deferredLengthString.inc"
 #define _map Integer64StringMap
 #define _iterator Integer64StringMapIterator
+#define _pair Integer64StringMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64UnlimitedMap.F90
+++ b/src/Integer64UnlimitedMap.F90
@@ -5,6 +5,7 @@ module gFTL_Integer64UnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map Integer64UnlimitedMap
 #define _iterator Integer64UnlimitedMapIterator
+#define _pair Integer64UnlimitedMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/Integer64UnlimitedMap.F90
+++ b/src/Integer64UnlimitedMap.F90
@@ -5,7 +5,7 @@ module gFTL_Integer64UnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map Integer64UnlimitedMap
 #define _iterator Integer64UnlimitedMapIterator
-#define _pair Integer64UnlimitedMapPair
+#define _pair Integer64UnlimitedPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/IntegerComplex128Map.F90
+++ b/src/IntegerComplex128Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerComplex128Map
 #  define _value type(complex(kind=REAL128))
 #  define _map IntegerComplex128Map
 #  define _iterator IntegerComplex128MapIterator
-#  define _pair IntegerComplex128MapPair
+#  define _pair IntegerComplex128Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplex128Map.F90
+++ b/src/IntegerComplex128Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerComplex128Map
 #  define _value type(complex(kind=REAL128))
 #  define _map IntegerComplex128Map
 #  define _iterator IntegerComplex128MapIterator
+#  define _pair IntegerComplex128MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplex32Map.F90
+++ b/src/IntegerComplex32Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerComplex32Map
 #  define _value type(complex(kind=REAL32))
 #  define _map IntegerComplex32Map
 #  define _iterator IntegerComplex32MapIterator
-#  define _pair IntegerComplex32MapPair
+#  define _pair IntegerComplex32Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplex32Map.F90
+++ b/src/IntegerComplex32Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerComplex32Map
 #  define _value type(complex(kind=REAL32))
 #  define _map IntegerComplex32Map
 #  define _iterator IntegerComplex32MapIterator
+#  define _pair IntegerComplex32MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplex64Map.F90
+++ b/src/IntegerComplex64Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerComplex64Map
 #  define _value type(complex(kind=REAL64))
 #  define _map IntegerComplex64Map
 #  define _iterator IntegerComplex64MapIterator
+#  define _pair IntegerComplex64MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplex64Map.F90
+++ b/src/IntegerComplex64Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerComplex64Map
 #  define _value type(complex(kind=REAL64))
 #  define _map IntegerComplex64Map
 #  define _iterator IntegerComplex64MapIterator
-#  define _pair IntegerComplex64MapPair
+#  define _pair IntegerComplex64Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplexMap.F90
+++ b/src/IntegerComplexMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerComplexMap
 #  define _value type(complex)
 #  define _map IntegerComplexMap
 #  define _iterator IntegerComplexMapIterator
-#  define _pair IntegerComplexMapPair
+#  define _pair IntegerComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerComplexMap.F90
+++ b/src/IntegerComplexMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerComplexMap
 #  define _value type(complex)
 #  define _map IntegerComplexMap
 #  define _iterator IntegerComplexMapIterator
+#  define _pair IntegerComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerDoubleComplexMap.F90
+++ b/src/IntegerDoubleComplexMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerDoubleComplexMap
 #  define _value type(complex(kind=kind(0.d0)))
 #  define _map IntegerDoubleComplexMap
 #  define _iterator IntegerDoubleComplexMapIterator
-#  define _pair IntegerDoubleComplexMapPair
+#  define _pair IntegerDoubleComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerDoubleComplexMap.F90
+++ b/src/IntegerDoubleComplexMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerDoubleComplexMap
 #  define _value type(complex(kind=kind(0.d0)))
 #  define _map IntegerDoubleComplexMap
 #  define _iterator IntegerDoubleComplexMapIterator
+#  define _pair IntegerDoubleComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerDoubleMap.F90
+++ b/src/IntegerDoubleMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerDoubleMap
 #  define _value type(double precision)
 #  define _map IntegerDoubleMap
 #  define _iterator IntegerDoubleMapIterator
+#  define _pair IntegerDoubleMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerDoubleMap.F90
+++ b/src/IntegerDoubleMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerDoubleMap
 #  define _value type(double precision)
 #  define _map IntegerDoubleMap
 #  define _iterator IntegerDoubleMapIterator
-#  define _pair IntegerDoubleMapPair
+#  define _pair IntegerDoublePair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerInteger32Map.F90
+++ b/src/IntegerInteger32Map.F90
@@ -18,7 +18,7 @@ module gFTL_IntegerInteger32Map
 #  define _value type(integer(kind=INT32))
 #  define _map IntegerInteger32Map
 #  define _iterator IntegerInteger32MapIterator
-#  define _pair IntegerInteger32MapPair
+#  define _pair IntegerInteger32Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerInteger32Map.F90
+++ b/src/IntegerInteger32Map.F90
@@ -18,6 +18,7 @@ module gFTL_IntegerInteger32Map
 #  define _value type(integer(kind=INT32))
 #  define _map IntegerInteger32Map
 #  define _iterator IntegerInteger32MapIterator
+#  define _pair IntegerInteger32MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerInteger64Map.F90
+++ b/src/IntegerInteger64Map.F90
@@ -18,6 +18,7 @@ module gFTL_IntegerInteger64Map
 #  define _value type(integer(kind=INT64))
 #  define _map IntegerInteger64Map
 #  define _iterator IntegerInteger64MapIterator
+#  define _pair IntegerInteger64MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerInteger64Map.F90
+++ b/src/IntegerInteger64Map.F90
@@ -18,7 +18,7 @@ module gFTL_IntegerInteger64Map
 #  define _value type(integer(kind=INT64))
 #  define _map IntegerInteger64Map
 #  define _iterator IntegerInteger64MapIterator
-#  define _pair IntegerInteger64MapPair
+#  define _pair IntegerInteger64Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerIntegerMap.F90
+++ b/src/IntegerIntegerMap.F90
@@ -16,7 +16,7 @@ module gFTL_IntegerIntegerMap
 #  define _value type(integer)
 #  define _map IntegerIntegerMap
 #  define _iterator IntegerIntegerMapIterator
-#  define _pair IntegerIntegerMapPair
+#  define _pair IntegerIntegerPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerIntegerMap.F90
+++ b/src/IntegerIntegerMap.F90
@@ -16,6 +16,7 @@ module gFTL_IntegerIntegerMap
 #  define _value type(integer)
 #  define _map IntegerIntegerMap
 #  define _iterator IntegerIntegerMapIterator
+#  define _pair IntegerIntegerMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerLogicalMap.F90
+++ b/src/IntegerLogicalMap.F90
@@ -16,6 +16,7 @@ module gFTL_IntegerLogicalMap
 #  define _value type(logical)
 #  define _map IntegerLogicalMap
 #  define _iterator IntegerLogicalMapIterator
+#  define _pair IntegerLogicalMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerLogicalMap.F90
+++ b/src/IntegerLogicalMap.F90
@@ -16,7 +16,7 @@ module gFTL_IntegerLogicalMap
 #  define _value type(logical)
 #  define _map IntegerLogicalMap
 #  define _iterator IntegerLogicalMapIterator
-#  define _pair IntegerLogicalMapPair
+#  define _pair IntegerLogicalPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal128Map.F90
+++ b/src/IntegerReal128Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerReal128Map
 #  define _value type(real(kind=REAL128))
 #  define _map IntegerReal128Map
 #  define _iterator IntegerReal128MapIterator
+#  define _pair IntegerReal128MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal128Map.F90
+++ b/src/IntegerReal128Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerReal128Map
 #  define _value type(real(kind=REAL128))
 #  define _map IntegerReal128Map
 #  define _iterator IntegerReal128MapIterator
-#  define _pair IntegerReal128MapPair
+#  define _pair IntegerReal128Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal32Map.F90
+++ b/src/IntegerReal32Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerReal32Map
 #  define _value type(real(kind=REAL32))
 #  define _map IntegerReal32Map
 #  define _iterator IntegerReal32MapIterator
+#  define _pair IntegerReal32MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal32Map.F90
+++ b/src/IntegerReal32Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerReal32Map
 #  define _value type(real(kind=REAL32))
 #  define _map IntegerReal32Map
 #  define _iterator IntegerReal32MapIterator
-#  define _pair IntegerReal32MapPair
+#  define _pair IntegerReal32Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal64Map.F90
+++ b/src/IntegerReal64Map.F90
@@ -19,7 +19,7 @@ module gFTL_IntegerReal64Map
 #  define _value type(real(kind=REAL64))
 #  define _map IntegerReal64Map
 #  define _iterator IntegerReal64MapIterator
-#  define _pair IntegerReal64MapPair
+#  define _pair IntegerReal64Pair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerReal64Map.F90
+++ b/src/IntegerReal64Map.F90
@@ -19,6 +19,7 @@ module gFTL_IntegerReal64Map
 #  define _value type(real(kind=REAL64))
 #  define _map IntegerReal64Map
 #  define _iterator IntegerReal64MapIterator
+#  define _pair IntegerReal64MapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerRealMap.F90
+++ b/src/IntegerRealMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerRealMap
 #  define _value type(real)
 #  define _map IntegerRealMap
 #  define _iterator IntegerRealMapIterator
-#  define _pair IntegerRealMapPair
+#  define _pair IntegerRealPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerRealMap.F90
+++ b/src/IntegerRealMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerRealMap
 #  define _value type(real)
 #  define _map IntegerRealMap
 #  define _iterator IntegerRealMapIterator
+#  define _pair IntegerRealMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerStringMap.F90
+++ b/src/IntegerStringMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerStringMap
 #  include "types/value_deferredLengthString.inc"
 #  define _map IntegerStringMap
 #  define _iterator IntegerStringMapIterator
-#  define _pair IntegerStringMapPair
+#  define _pair IntegerStringPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerStringMap.F90
+++ b/src/IntegerStringMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerStringMap
 #  include "types/value_deferredLengthString.inc"
 #  define _map IntegerStringMap
 #  define _iterator IntegerStringMapIterator
+#  define _pair IntegerStringMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerUnlimitedMap.F90
+++ b/src/IntegerUnlimitedMap.F90
@@ -17,6 +17,7 @@ module gFTL_IntegerUnlimitedMap
 #  include "types/value_unlimitedPoly.inc"
 #  define _map IntegerUnlimitedMap
 #  define _iterator IntegerUnlimitedMapIterator
+#  define _pair IntegerUnlimitedMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/IntegerUnlimitedMap.F90
+++ b/src/IntegerUnlimitedMap.F90
@@ -17,7 +17,7 @@ module gFTL_IntegerUnlimitedMap
 #  include "types/value_unlimitedPoly.inc"
 #  define _map IntegerUnlimitedMap
 #  define _iterator IntegerUnlimitedMapIterator
-#  define _pair IntegerUnlimitedMapPair
+#  define _pair IntegerUnlimitedPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringComplex128Map.F90
+++ b/src/StringComplex128Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringComplex128Map
 #define _value type(complex(kind=REAL128))
 #define _map StringComplex128Map
 #define _iterator StringComplex128MapIterator
-#define _pair StringComplex128MapPair
+#define _pair StringComplex128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplex128Map.F90
+++ b/src/StringComplex128Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringComplex128Map
 #define _value type(complex(kind=REAL128))
 #define _map StringComplex128Map
 #define _iterator StringComplex128MapIterator
+#define _pair StringComplex128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplex32Map.F90
+++ b/src/StringComplex32Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringComplex32Map
 #define _value type(complex(kind=REAL32))
 #define _map StringComplex32Map
 #define _iterator StringComplex32MapIterator
-#define _pair StringComplex32MapPair
+#define _pair StringComplex32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplex32Map.F90
+++ b/src/StringComplex32Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringComplex32Map
 #define _value type(complex(kind=REAL32))
 #define _map StringComplex32Map
 #define _iterator StringComplex32MapIterator
+#define _pair StringComplex32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplex64Map.F90
+++ b/src/StringComplex64Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringComplex64Map
 #define _value type(complex(kind=REAL64))
 #define _map StringComplex64Map
 #define _iterator StringComplex64MapIterator
+#define _pair StringComplex64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplex64Map.F90
+++ b/src/StringComplex64Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringComplex64Map
 #define _value type(complex(kind=REAL64))
 #define _map StringComplex64Map
 #define _iterator StringComplex64MapIterator
-#define _pair StringComplex64MapPair
+#define _pair StringComplex64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringComplexMap.F90
+++ b/src/StringComplexMap.F90
@@ -17,6 +17,7 @@ module gFTL_StringComplexMap
 #  define _value type(complex)
 #  define _map StringComplexMap
 #  define _iterator StringComplexMapIterator
+#  define _pair StringComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringComplexMap.F90
+++ b/src/StringComplexMap.F90
@@ -17,7 +17,7 @@ module gFTL_StringComplexMap
 #  define _value type(complex)
 #  define _map StringComplexMap
 #  define _iterator StringComplexMapIterator
-#  define _pair StringComplexMapPair
+#  define _pair StringComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringDoubleComplexMap.F90
+++ b/src/StringDoubleComplexMap.F90
@@ -17,6 +17,7 @@ module gFTL_StringDoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map StringDoubleComplexMap
 #  define _iterator StringDoubleComplexMapIterator
+#  define _pair StringDoubleComplexMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringDoubleComplexMap.F90
+++ b/src/StringDoubleComplexMap.F90
@@ -17,7 +17,7 @@ module gFTL_StringDoubleComplexMap
 #  define _value type(complex(kind=kind(0.0d0)))
 #  define _map StringDoubleComplexMap
 #  define _iterator StringDoubleComplexMapIterator
-#  define _pair StringDoubleComplexMapPair
+#  define _pair StringDoubleComplexPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringDoubleMap.F90
+++ b/src/StringDoubleMap.F90
@@ -17,6 +17,7 @@ module gFTL_StringDoubleMap
 #  define _value type(double precision)
 #  define _map StringDoubleMap
 #  define _iterator StringDoubleMapIterator
+#  define _pair StringDoubleMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringDoubleMap.F90
+++ b/src/StringDoubleMap.F90
@@ -17,7 +17,7 @@ module gFTL_StringDoubleMap
 #  define _value type(double precision)
 #  define _map StringDoubleMap
 #  define _iterator StringDoubleMapIterator
-#  define _pair StringDoubleMapPair
+#  define _pair StringDoublePair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringInteger32Map.F90
+++ b/src/StringInteger32Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringInteger32Map
 #define _value type(integer(kind=INT32))
 #define _map StringInteger32Map
 #define _iterator StringInteger32MapIterator
-#define _pair StringInteger32MapPair
+#define _pair StringInteger32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringInteger32Map.F90
+++ b/src/StringInteger32Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringInteger32Map
 #define _value type(integer(kind=INT32))
 #define _map StringInteger32Map
 #define _iterator StringInteger32MapIterator
+#define _pair StringInteger32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringInteger64Map.F90
+++ b/src/StringInteger64Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringInteger64Map
 #define _value type(integer(kind=INT64))
 #define _map StringInteger64Map
 #define _iterator StringInteger64MapIterator
+#define _pair StringInteger64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringInteger64Map.F90
+++ b/src/StringInteger64Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringInteger64Map
 #define _value type(integer(kind=INT64))
 #define _map StringInteger64Map
 #define _iterator StringInteger64MapIterator
-#define _pair StringInteger64MapPair
+#define _pair StringInteger64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringIntegerMap.F90
+++ b/src/StringIntegerMap.F90
@@ -17,6 +17,7 @@ module gFTL_StringIntegerMap
 #  define _value type(integer)
 #  define _map StringIntegerMap
 #  define _iterator StringIntegerMapIterator
+#  define _pair StringIntegerMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringIntegerMap.F90
+++ b/src/StringIntegerMap.F90
@@ -17,7 +17,7 @@ module gFTL_StringIntegerMap
 #  define _value type(integer)
 #  define _map StringIntegerMap
 #  define _iterator StringIntegerMapIterator
-#  define _pair StringIntegerMapPair
+#  define _pair StringIntegerPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringLogicalMap.F90
+++ b/src/StringLogicalMap.F90
@@ -4,7 +4,7 @@ module gFTL_StringLogicalMap
 #define _value type(logical)
 #define _map StringLogicalMap
 #define _iterator StringLogicalMapIterator
-#define _pair StringLogicalMapPair
+#define _pair StringLogicalPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringLogicalMap.F90
+++ b/src/StringLogicalMap.F90
@@ -4,6 +4,7 @@ module gFTL_StringLogicalMap
 #define _value type(logical)
 #define _map StringLogicalMap
 #define _iterator StringLogicalMapIterator
+#define _pair StringLogicalMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal128Map.F90
+++ b/src/StringReal128Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringReal128Map
 #define _value type(real(kind=REAL128))
 #define _map StringReal128Map
 #define _iterator StringReal128MapIterator
-#define _pair StringReal128MapPair
+#define _pair StringReal128Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal128Map.F90
+++ b/src/StringReal128Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringReal128Map
 #define _value type(real(kind=REAL128))
 #define _map StringReal128Map
 #define _iterator StringReal128MapIterator
+#define _pair StringReal128MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal32Map.F90
+++ b/src/StringReal32Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringReal32Map
 #define _value type(real(kind=REAL32))
 #define _map StringReal32Map
 #define _iterator StringReal32MapIterator
+#define _pair StringReal32MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal32Map.F90
+++ b/src/StringReal32Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringReal32Map
 #define _value type(real(kind=REAL32))
 #define _map StringReal32Map
 #define _iterator StringReal32MapIterator
-#define _pair StringReal32MapPair
+#define _pair StringReal32Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal64Map.F90
+++ b/src/StringReal64Map.F90
@@ -5,7 +5,7 @@ module gFTL_StringReal64Map
 #define _value type(real(kind=REAL64))
 #define _map StringReal64Map
 #define _iterator StringReal64MapIterator
-#define _pair StringReal64MapPair
+#define _pair StringReal64Pair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringReal64Map.F90
+++ b/src/StringReal64Map.F90
@@ -5,6 +5,7 @@ module gFTL_StringReal64Map
 #define _value type(real(kind=REAL64))
 #define _map StringReal64Map
 #define _iterator StringReal64MapIterator
+#define _pair StringReal64MapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringRealMap.F90
+++ b/src/StringRealMap.F90
@@ -16,7 +16,7 @@ module gFTL_StringRealMap
 #  define _value type(real)
 #  define _map StringRealMap
 #  define _iterator StringRealMapIterator
-#  define _pair StringRealMapPair
+#  define _pair StringRealPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringRealMap.F90
+++ b/src/StringRealMap.F90
@@ -16,6 +16,7 @@ module gFTL_StringRealMap
 #  define _value type(real)
 #  define _map StringRealMap
 #  define _iterator StringRealMapIterator
+#  define _pair StringRealMapPair
 #  define _alt
 
 #  include "templates/map.inc"

--- a/src/StringStringMap.F90
+++ b/src/StringStringMap.F90
@@ -4,6 +4,7 @@ module gFTL_StringStringMap
 #include "types/value_deferredLengthString.inc"
 #define _map StringStringMap
 #define _iterator StringStringMapIterator
+#define _pair StringStringMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringStringMap.F90
+++ b/src/StringStringMap.F90
@@ -4,7 +4,7 @@ module gFTL_StringStringMap
 #include "types/value_deferredLengthString.inc"
 #define _map StringStringMap
 #define _iterator StringStringMapIterator
-#define _pair StringStringMapPair
+#define _pair StringStringPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringUnlimitedMap.F90
+++ b/src/StringUnlimitedMap.F90
@@ -4,6 +4,7 @@ module gFTL_StringUnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map StringUnlimitedMap
 #define _iterator StringUnlimitedMapIterator
+#define _pair StringUnlimitedMapPair
 #define _alt
 
 #include "templates/map.inc"

--- a/src/StringUnlimitedMap.F90
+++ b/src/StringUnlimitedMap.F90
@@ -4,7 +4,7 @@ module gFTL_StringUnlimitedMap
 #include "types/value_unlimitedPoly.inc"
 #define _map StringUnlimitedMap
 #define _iterator StringUnlimitedMapIterator
-#define _pair StringUnlimitedMapPair
+#define _pair StringUnlimitedPair
 #define _alt
 
 #include "templates/map.inc"


### PR DESCRIPTION
This PR adds a specific typename (e.g. StringRealMapPair) for all pair types contained within map types.  It is analogous to what is already done for iterator types.

This fixes a compile issue for pFUnit under the XLF compiler (see Goddard-Fortran-Ecosystem/pFUnit#208).  It has been tested under Intel and GNU compilers.