### PR TITLE
Don't run CI if a markdown file changes or on all pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: CI Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Do not run if the only files changed cannot affect the build
+    paths-ignore:
+      - "**.md"
+      - "**.MD"
+      - "LICENSE"
 
 jobs:
   GNU:


### PR DESCRIPTION
I'm not sure there's a need to run CI on all pushes as we mainly care about it at pull request time.

Also, there is no need to run CI if a markdown file or the `LICENSE` changes!