### PR TITLE
Modifications to Intel compiler flags on Windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for compiling on Windows with Intel compiler.
+
 ## [1.3.3] - 2021-10-27
 
 ### Changed

--- a/cmake/Intel.cmake
+++ b/cmake/Intel.cmake
@@ -3,19 +3,21 @@
 if(WIN32)
   set(no_optimize "-Od")
   set(check_all "-check:all")
+  set(cpp "-fpp")
+  set(save-temps "-Qsave-temps")
+  set(disable_warning_for_long_names "-Qdiag-disable:5462")
 else()
-  set(no_optimize "-O0")
+  set(no_optimize "-Od")
   set(check_all "-check all")
+  set(cpp "-cpp")
+  set(save-temps "-save-temps")
+  set(disable_warning_for_long_names "-diag-disable 5462")
 endif()
   
-
-set(disable_warning_for_long_names "-diag-disable 5462")
 set(traceback "-traceback")
-set(cpp "-cpp")
-set(save-temps "-save-temps")
 
 set(CMAKE_Fortran_Flags_ALL "${cpp} ${disable_warning_for_long_names}")
-set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${save-temps} ${CMAKE_Fortran_Flags_ALL} -save-temps")
+set(CMAKE_Fortran_FLAGS_DEBUG  "${no_optimize} ${check_all} ${save-temps} ${CMAKE_Fortran_Flags_ALL}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O3 ${CMAKE_Fortran_Flags_ALL}")
 
 add_definitions(-D_INTEL)


### PR DESCRIPTION
The flags -save-temps, -diag-disable 5462, -check:all, -O0, and -cpp are different for the Windows version of the Intel Fortran compiler.