### PR TITLE
Add NVHPC Support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NVHPC.cmake` file for NVHPC support
+
 ## [1.3.6] - 2021-11-16
 
 ### Fixed

--- a/cmake/NVHPC.cmake
+++ b/cmake/NVHPC.cmake
@@ -1,0 +1,9 @@
+# Compiler specific flags for PGI Fortran compiler
+
+set(traceback "-traceback")
+set(check_all "-Mbounds -Mchkstk")
+
+set(CMAKE_Fortran_FLAGS_DEBUG  "-O0")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS "-g ${traceback} ${check_all} -Mallocatable=03")
+

--- a/cmake/PGI.cmake
+++ b/cmake/PGI.cmake
@@ -1,5 +1,4 @@
 # Compiler specific flags for PGI Fortran compiler
-# (or is this now NVIDIA?)
 
 set(traceback "-traceback")
 if( CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 20.11 )


### PR DESCRIPTION
This PR adds an `NVHPC.cmake` file identical to that used in pFUnit