### PR TITLE
Use CMake functions to check Fortran features

### DIFF
--- a/cmake/check_intrinsic_kinds.cmake
+++ b/cmake/check_intrinsic_kinds.cmake
@@ -9,9 +9,9 @@ CHECK_Fortran_SOURCE_RUN (
   ${CMAKE_CURRENT_LIST_DIR}/trial_sources/INT_DEFAULT_KIND.F90
   _INT_DEFAULT_KIND
   )
+
 foreach (kind 8 16 32 64)
-  set(CMAKE_REQUIRED_FLAGS = -fpp)
-  set(CMAKE_REQUIRED_DEFINITIONS -D_KIND=INT${kind})
+  set(CMAKE_REQUIRED_DEFINITIONS "-D_KIND=INT${kind}")
 
   CHECK_Fortran_SOURCE_RUN (
     ${CMAKE_CURRENT_LIST_DIR}/trial_sources/INT_KIND.F90
@@ -31,30 +31,11 @@ CHECK_Fortran_SOURCE_RUN (
   )
 
 foreach (kind 32 64 128)
-  set(CMAKE_REQUIRED_FLAGS = -fpp)
-  set(CMAKE_REQUIRED_DEFINITIONS -D_KIND=REAL${kind})
+  set(CMAKE_REQUIRED_DEFINITIONS "-D_KIND=REAL${kind}")
 
-  try_compile (
-    code_compiles
-    ${GFTL_SHARED_BINARY_DIR}
+  CHECK_Fortran_SOURCE_RUN (
     ${CMAKE_CURRENT_LIST_DIR}/trial_sources/REAL_KIND.F90
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}")
-  
-  if (code_compiles)
-    CHECK_Fortran_SOURCE_RUN (
-      ${CMAKE_CURRENT_LIST_DIR}/trial_sources/REAL_KIND.F90
-      _ISO_REAL${kind}
-      )
-  endif ()
-  
-  try_compile (
-    code_compiles
-    ${GFTL_SHARED_BINARY_DIR}
-    ${CMAKE_CURRENT_LIST_DIR}/trial_sources/REAL_KIND.F90
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}")
-  
+    _ISO_REAL${kind}
+    )
 
 endforeach()
-
-
-

--- a/cmake/fortran_try.cmake
+++ b/cmake/fortran_try.cmake
@@ -1,57 +1,52 @@
-macro (CHECK_FORTRAN_SOURCE_RUN file var)
 
-  try_run (
-    run compile
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${file}
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
-    RUN_OUTPUT_VARIABLE ${var}
-    )
+macro (CHECK_Fortran_SOURCE_RUN file var)
 
-  # Successful runs return "0", which is opposite of CMake sense of "if":
-  if (NOT run)
-    string(STRIP ${${var}} ${var})
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message(STATUS "Performing Test ${var}: SUCCESS (value=${${var}})")
-    endif ()
-    
-    add_definitions(-D${var}=${${var}})
-    
-  else ()
-    
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message(STATUS "Performing Test ${var}: FAILURE")
-    endif ()
-    
+  # Wrapper to check_fortran_source_runs to add a compiler definition on success
+  # See https://cmake.org/cmake/help/latest/module/CheckFortranSourceRuns.html
+
+  include(CheckFortranSourceRuns)
+
+  file(READ ${file} source)  
+  # message(${source})
+
+  check_fortran_source_runs(
+    ${source}
+    # "character :: b; b = 'a'; end"
+    ${var}
+    SRC_EXT F90
+  )
+
+  # Note the double brackets, ${ ${ } }, below. This evaluates the contents
+  # of the variable. A single bracket also works in an if-statement, but
+  # to print the contents use `message(${${var}})`.
+  if (${${var}})
+    add_definitions(-D${var})
   endif ()
 
-endmacro (CHECK_FORTRAN_SOURCE_RUN)
+endmacro ()
 
 
-macro (CHECK_FORTRAN_SOURCE_COMPILE file var)
+macro (CHECK_Fortran_SOURCE_COMPILE file var)
+  include(CheckFortranSourceCompiles)
 
-  try_compile (
-    code_compiles
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${file}
-    CMAKE_FLAGS "-DCOMPILE_DEFINITIONS=${CMAKE_REQUIRED_DEFINITIONS}"
-    )
+  # Wrapper to check_fortran_source_compiles to add a compiler definition on success
+  # See https://cmake.org/cmake/help/latest/module/CheckFortranSourceCompiles.html
 
-  if (${code_compiles})
+  include(CheckFortranSourceCompiles)
 
-    set(${var} SUCCESS)
-    if (NOT CMAKE_REQUIRED_QUIET)
-      message (STATUS "Performing Test ${var}: SUCCESS")
-    endif ()
+  file(READ ${file} source)  
 
+  check_fortran_source_compiles(
+    ${source}
+    ${var}
+    SRC_EXT F90
+  )
+
+  # Note the double brackets, ${ ${ } }, below. This evaluates the contents
+  # of the variable. A single bracket also works in an if-statement, but
+  # to print the contents use `message(${${var}})`.
+  if (${${var}})
     add_definitions(-D${var})
+  endif ()
 
-  else ()
-
-      if (NOT CMAKE_REQUIRED_QUIET)
-	message (STATUS "Performing Test ${var}: BUILD FAILURE")
-      endif ()
-
-  endif()
-
-endmacro (CHECK_FORTRAN_SOURCE_COMPILE)
+endmacro ()


### PR DESCRIPTION
This pull request uses CMake functions to check for Fortran features in the compiler. The major benefit is that these CMake functions handle checking whether the feature has already been checked. On the first CMake config, all checks run and the variables are stored in the cache. The checks will not run on subsequent CMake configs. Using these functions also handles the messaging to the terminal and simplifies the code here quite a bit.

Unfortunately for me, I reworked these functions and then saw #48 only when I went to open this pull request, so this is partially redundant. However, while #48 solves the cache-checking problem, it's still using a manual process rather than leveraging the existing CMake functions. I've also made this change in pFUnit (see https://github.com/rafmudaf/pFUnit/commit/d7bbd6da35713a446c81c34bb424eb47f296bc60). If this change is merged, I'll update the gFTL-shared submodule in pFUnit and open a pull request for the changes there.

Additionally, I suggest that these functions also be made consistent in gFTL. @tclune if that sounds good to you, I'll make the change there and include the updated git-submodule in this pull request.