### PR TITLE
Add quiet flag for NAG Fortran

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `-quiet` flag for NAG Fortran
+
 ## [1.8.0] - 2024-03-03
 
 ### Added

--- a/cmake/NAG.cmake
+++ b/cmake/NAG.cmake
@@ -6,7 +6,7 @@ set (CRAY_POINTER "")
 set (EXTENDED_SOURCE "-132")
 
 set (check_kinds "-kind=unique")
-set (CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C=all -Wp,-P") # -C=undefined")
-#set (CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C=all") # -C=undefined")
-set (CMAKE_Fortran_FLAGS_RELEASE "-O3 -g -Wp,-P")
+set (CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -quiet -C=all -Wp,-P") # -C=undefined")
+#set (CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -quiet -C=all") # -C=undefined")
+set (CMAKE_Fortran_FLAGS_RELEASE "-O3 -g -quiet -Wp,-P")
 


### PR DESCRIPTION
This PR adds `-quiet` to the NAG Fortran compiler flags. This flag will "[s]uppress the compiler banner and the summary line, so that only diagnostic messages will appear."