### PR TITLE
Add install of v2-as-default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added gftl-shared-v2-as-default to install list
 - Added `-quiet` flag for NAG Fortran
 
 ## [1.8.0] - 2024-03-03

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -154,3 +154,4 @@ target_link_libraries (gftl-shared-v2 PUBLIC GFTL::gftl-v2)
 
 install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod/ DESTINATION ${dest}/include/v2)
 install (TARGETS gftl-shared-v2 EXPORT GFTL_SHARED DESTINATION "${dest}/lib")
+install (TARGETS ${v2-default} EXPORT GFTL_SHARED DESTINATION "${dest}/lib")


### PR DESCRIPTION
This adds the `gftl-shared-v2-as-default` directory to the install list for gftl-shared.  This will be needed by an upcoming pFUnit change that switches that package to use the v2 interfaces.

