### PR TITLE
Add Ubuntu 24 for gfortran-13 support, remove macos-12, add macos-14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-13]
+        os: [ubuntu-24.04, macos-12, macos-13]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
           - os: macos-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-12, macos-13]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
-          - os: macos-12
-            compiler: gfortran-10
           - os: macos-13
+            compiler: gfortran-10
+          - os: macos-14
             compiler: gfortran-10
           - os: ubuntu-24.04
             compiler: gfortran-10
+          - os: ubuntu-24.04
+            compiler: gfortran-11
           - os: ubuntu-22.04
             compiler: gfortran-13
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-12, macos-13]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-12, macos-13]
         compiler: [gfortran-10, gfortran-11, gfortran-12, gfortran-13]
         exclude:
           - os: macos-12
             compiler: gfortran-10
           - os: macos-13
             compiler: gfortran-10
+          - os: ubuntu-24.04
+            compiler: gfortran-10
+          - os: ubuntu-22.04
+            compiler: gfortran-13
 
       # fail-fast if set to 'true' here is good for production, but when
       # debugging, set to 'false'. fail-fast means if *any* ci test in the matrix fails

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `-quiet` flag for NAG Fortran
 - Remove `macos-11` from GitHub Actions, add `macos-12`
+- Moved CI to use Ubuntu 24 as that has `gfortran-13`
 
 ## [1.8.0] - 2024-03-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `-quiet` flag for NAG Fortran
 - Remove `macos-11` from GitHub Actions, add `macos-12`
-- Moved CI to use Ubuntu 24 as that has `gfortran-13`
+- Add Ubuntu 24 to CI that has `gfortran-13`. Remove `gfortran-13` test from ubuntu 22
 
 ## [1.8.0] - 2024-03-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added gftl-shared-v2-as-default to install list
 - Added `-quiet` flag for NAG Fortran
-- Remove `macos-11` from GitHub Actions, add `macos-12`
+- Remove `macos-11` and `macos-12` from GitHub Actions, move to use `macos-13` and `macos-14`
 - Add Ubuntu 24 to CI that has `gfortran-13`. Remove `gfortran-13` test from ubuntu 22
 
 ## [1.8.0] - 2024-03-03


### PR DESCRIPTION
As shown in #77, `gfortran-13` support was removed by GitHub in https://github.com/actions/runner-images/issues/9679

But it does exist in Ubuntu 24. But that does not have gcc 10. So we add Ubuntu 24 for 13.

Also, remove `macos-12` and add `macos-14`