### PR TITLE
Update to gFTL v1.17.0 and release v1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.24)
 # the library gftl-shared retain the hyphen (and lower case)
 
 project (GFTL_SHARED
-  VERSION 1.11.0
+  VERSION 1.12.0
   LANGUAGES Fortran)
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,8 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-02-23
+
 ### Changed
 
+- Updated gFTL to v1.17.0
 - Remove `gfortran-12` from macos runners, clean up CI
 
 ## [1.11.0] - 2025-09-29


### PR DESCRIPTION
## Summary

- Updated gFTL submodule from v1.16.0 to v1.17.0
- Bumped gFTL-shared version to 1.12.0
- Updated ChangeLog.md with release notes for v1.12.0

This update brings in the latest improvements from the gFTL library.